### PR TITLE
swagger: fixed invalid specification (#5485)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,8 +102,8 @@ jobs:
               echo "ERROR: The swagger.json file is not in sync with the yaml specification. Run 'rake swagger:build' and commit 'swagger/swagger.json'."
               exit 1
             fi
-            curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.3.0/openapi-generator-cli-5.3.0.jar > ~/tmp/openapi-generator-cli-5.3.0.jar
-            java -jar ~/tmp/openapi-generator-cli-5.3.0.jar validate -i swagger/swagger.json
+            curl -L https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.3.0/openapi-generator-cli-6.3.0.jar > ~/tmp/openapi-generator-cli-6.3.0.jar
+            java -jar ~/tmp/openapi-generator-cli-6.3.0.jar validate -i swagger/swagger.json
             
       # Database setup
       - run: yarn install --check-files

--- a/swagger/definitions/index.yml
+++ b/swagger/definitions/index.yml
@@ -158,13 +158,6 @@ conversation_status_toggle:
 conversation_labels:
   $ref: ./resource/extension/conversation/labels.yml
 
-## message
-extended_message:
-  allOf:
-    - $ref: '#/definitions/generic_id'
-    - $ref: '#/definitions/message'
-    - $ref: ./resource/extension/message/with_source_sender.yml
-
 
 ## report
 account_summary:

--- a/swagger/definitions/request/contact/create.yml
+++ b/swagger/definitions/request/contact/create.yml
@@ -14,7 +14,8 @@ properties:
     type: string
     description: phone number of the contact
   avatar:
-    type: string <binary>
+    type: string
+    format: binary
     description: Send the form data with the avatar image binary or use the avatar_url
   avatar_url:
     type: string

--- a/swagger/definitions/request/contact/update.yml
+++ b/swagger/definitions/request/contact/update.yml
@@ -10,7 +10,8 @@ properties:
     type: string
     description: phone number of the contact
   avatar:
-    type: string <binary>
+    type: string
+    format: binary
     description: Send the form data with the avatar image binary or use the avatar_url
   avatar_url:
     type: string

--- a/swagger/definitions/resource/extension/conversation/show.yml
+++ b/swagger/definitions/resource/extension/conversation/show.yml
@@ -1,5 +1,4 @@
 type: object
 allOf:
-  - $ref: '#/definitions/generic_id'
   - $ref: '#/definitions/conversation'
   - $ref: '../contact/conversation.yml'

--- a/swagger/definitions/resource/extension/message/with_source_sender.yml
+++ b/swagger/definitions/resource/extension/message/with_source_sender.yml
@@ -2,5 +2,3 @@ type: object
 properties:
   source_id:
     type: number
-  sender:
-    type: object

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -5688,7 +5688,8 @@
           "description": "phone number of the contact"
         },
         "avatar": {
-          "type": "string <binary>",
+          "type": "string",
+          "format": "binary",
           "description": "Send the form data with the avatar image binary or use the avatar_url"
         },
         "avatar_url": {
@@ -5721,7 +5722,8 @@
           "description": "phone number of the contact"
         },
         "avatar": {
-          "type": "string <binary>",
+          "type": "string",
+          "format": "binary",
           "description": "Send the form data with the avatar image binary or use the avatar_url"
         },
         "avatar_url": {
@@ -6158,9 +6160,6 @@
       "type": "object",
       "allOf": [
         {
-          "$ref": "#/definitions/generic_id"
-        },
-        {
           "$ref": "#/definitions/conversation"
         },
         {
@@ -6236,27 +6235,6 @@
           }
         }
       }
-    },
-    "extended_message": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/generic_id"
-        },
-        {
-          "$ref": "#/definitions/message"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "source_id": {
-              "type": "number"
-            },
-            "sender": {
-              "type": "object"
-            }
-          }
-        }
-      ]
     },
     "account_summary": {
       "type": "object",


### PR DESCRIPTION
Currently, the swagger spec doesn't follow the Swagger 2.0 specification. So, I facing 4 errors when trying generate the Golang client for chatwoot.
Due to the spec, the binary field should use format: binary beside type: string

Signed-off-by: Giau. Tran Minh <hello@giautm.dev>
Co-authored-by: Sojan Jose <sojan@pepalo.com>