### PR TITLE
chore: Load only required APMs (#6497)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,13 +96,15 @@ gem 'slack-ruby-client'
 gem 'google-cloud-dialogflow'
 
 ##-- apm and error monitoring ---#
-gem 'ddtrace'
-gem 'elastic-apm'
-gem 'newrelic_rpm'
-gem 'scout_apm'
-gem 'sentry-rails', '~> 5.3', '>= 5.3.1'
-gem 'sentry-ruby', '~> 5.3'
-gem 'sentry-sidekiq', '~> 5.3', '>= 5.3.1'
+# loaded only when environment variables are set.
+# ref application.rb
+gem 'ddtrace', require: false
+gem 'elastic-apm', require: false
+gem 'newrelic_rpm', require: false
+gem 'scout_apm', require: false
+gem 'sentry-rails', require: false
+gem 'sentry-ruby', require: false
+gem 'sentry-sidekiq', require: false
 
 ##-- background job processing --##
 gem 'sidekiq', '~> 6.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -844,9 +844,9 @@ DEPENDENCIES
   rubocop-rspec
   scout_apm
   seed_dump
-  sentry-rails (~> 5.3, >= 5.3.1)
-  sentry-ruby (~> 5.3)
-  sentry-sidekiq (~> 5.3, >= 5.3.1)
+  sentry-rails
+  sentry-ruby
+  sentry-sidekiq
   shoulda-matchers
   sidekiq (~> 6.4.2)
   sidekiq-cron (~> 1.6, >= 1.6.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,20 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+## Load the specific APM agent
+# We rely on DOTENV to load the environment variables
+# We need these environment variables to load the specific APM agent
+Dotenv::Railtie.load
+require 'ddtrace' if ENV.fetch('DD_TRACE_AGENT_URL', false).present?
+require 'elastic-apm' if ENV.fetch('ELASTIC_APM_SECRET_TOKEN', false).present?
+require 'newrelic_rpm' if ENV.fetch('NEW_RELIC_LICENSE_KEY', false).present?
+require 'scout_apm' if ENV.fetch('SCOUT_KEY', false).present?
+if ENV.fetch('SENTRY_DSN', false).present?
+  require 'sentry-ruby'
+  require 'sentry-rails'
+  require 'sentry-sidekiq'
+end
+
 module Chatwoot
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/scout_apm.yml
+++ b/config/scout_apm.yml
@@ -1,0 +1,10 @@
+common: &defaults
+  name: <%= ENV.fetch('SCOUT_NAME', '') %>
+  key: <%= ENV.fetch('SCOUT_KEY', '') %>
+  monitor: <%= ENV['SCOUT_KEY'].present? && ENV.fetch('SCOUT_MONITOR', true)  %>
+
+test:
+  monitor: <%= ENV['SCOUT_KEY'].present? && ENV.fetch('SCOUT_MONITOR', true)  %>
+
+production:
+  <<: *defaults

--- a/spec/lib/chatwoot_exception_tracker_spec.rb
+++ b/spec/lib/chatwoot_exception_tracker_spec.rb
@@ -1,4 +1,6 @@
 require 'rails_helper'
+# explicitly requiring since we are loading apms conditionally in application.rb
+require 'sentry-ruby'
 
 describe ChatwootExceptionTracker do
   it 'use rails logger if no tracker is configured' do


### PR DESCRIPTION
- Disable requiring the gems for all the APMs 
- Switch to selectively requiring them.