### PR TITLE
feat: Ability to update CSAT over Client APIs (#6470)

### DIFF
--- a/spec/controllers/public/api/v1/inbox/messages_controller_spec.rb
+++ b/spec/controllers/public/api/v1/inbox/messages_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Public Inbox Contact Conversation Messages API', type: :request 
   end
 
   describe 'PATCH /public/api/v1/inboxes/{identifier}/contact/{source_id}/conversations/{conversation_id}/messages/{id}' do
-    it 'creates a message in the conversation' do
+    it 'updates a message in the conversation' do
       message = create(:message, account: conversation.account, inbox: conversation.inbox, conversation: conversation)
       patch "/public/api/v1/inboxes/#{api_channel.identifier}/contacts/#{contact_inbox.source_id}/conversations/" \
             "#{conversation.display_id}/messages/#{message.id}",
@@ -64,6 +64,36 @@ RSpec.describe 'Public Inbox Contact Conversation Messages API', type: :request 
       expect(response).to have_http_status(:success)
       data = JSON.parse(response.body)
       expect(data['content_attributes']['submitted_values'].first['title']).to eq 'test'
+    end
+
+    it 'updates CSAT survey response for the conversation' do
+      message = create(:message, account: conversation.account, inbox: conversation.inbox, conversation: conversation, content_type: 'input_csat')
+      # since csat survey is created in async job, we are mocking the creation.
+      create(:csat_survey_response, conversation: conversation, message: message, rating: 4, feedback_message: 'amazing experience')
+
+      patch "/public/api/v1/inboxes/#{api_channel.identifier}/contacts/#{contact_inbox.source_id}/conversations/" \
+            "#{conversation.display_id}/messages/#{message.id}",
+            params: { submitted_values: { csat_survey_response: { rating: 4, feedback_message: 'amazing experience' } } },
+            as: :json
+
+      expect(response).to have_http_status(:success)
+      data = JSON.parse(response.body)
+      expect(data['content_attributes']['submitted_values']['csat_survey_response']['feedback_message']).to eq 'amazing experience'
+      expect(data['content_attributes']['submitted_values']['csat_survey_response']['rating']).to eq 4
+    end
+
+    it 'returns update error if CSAT message sent more than 14 days' do
+      message = create(:message, account: conversation.account, inbox: conversation.inbox, conversation: conversation, content_type: 'input_csat',
+                                 created_at: 15.days.ago)
+      # since csat survey is created in async job, we are mocking the creation.
+      create(:csat_survey_response, conversation: conversation, message: message, rating: 4, feedback_message: 'amazing experience')
+
+      patch "/public/api/v1/inboxes/#{api_channel.identifier}/contacts/#{contact_inbox.source_id}/conversations/" \
+            "#{conversation.display_id}/messages/#{message.id}",
+            params: { submitted_values: { csat_survey_response: { rating: 4, feedback_message: 'amazing experience' } } },
+            as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
     end
   end
 end


### PR DESCRIPTION
This PR allows updating CSAT over Client APIs.

ref: #6328

Co-authored-by: Cristian Duta <Cristian.Duta@ti8m.ch>
Co-authored-by: Sojan Jose <sojan@pepalo.com>