### PR TITLE
chore: Bumped Ruby version on codespace image to 3.1.3 (#6490)

### DIFF
--- a/.devcontainer/Dockerfile.base
+++ b/.devcontainer/Dockerfile.base
@@ -30,7 +30,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     npm
 
 # Install rbenv and ruby
-ARG RUBY_VERSION="3.0.4"
+ARG RUBY_VERSION="3.1.3"
 RUN git clone https://github.com/rbenv/rbenv.git ~/.rbenv \
     &&  echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc \
     &&  echo 'eval "$(rbenv init -)"' >> ~/.bashrc


### PR DESCRIPTION
- Bumped Ruby version on codespace docker image to match the new Ruby version 3.1.3, which is required since from 2.14.