### PR TITLE
chore: add `--force-exclusion` option (#6535)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,7 +5,7 @@
 npx --no-install lint-staged
 
 # lint only staged ruby files
-git diff --name-only --cached | xargs ls -1 2>/dev/null | grep '\.rb$' | xargs bundle exec rubocop -a
+git diff --name-only --cached | xargs ls -1 2>/dev/null | grep '\.rb$' | xargs bundle exec rubocop --force-exclusion -a
 
 # stage rubocop changes to files
 git diff --name-only --cached | xargs git add


### PR DESCRIPTION
The pre-commit hook would format event those files excluded in the config. This is because the files were passed as args instead of the linter running on the entire project. When this happens, the exclude is not respect.

The --force-exclusion flag instructs our machine overlords to force exlucde files specified in the configuration Exclude even if they are explicitly passed as arguments.