### PR TITLE
chore: Disable error tracking for Whatsapp error webhooks (#6627)

### DIFF
--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -56,6 +56,8 @@ class Whatsapp::IncomingMessageBaseService
     return if unprocessable_message_type?(message_type)
 
     message = @processed_params[:messages].first
+    log_error(message) && return if error_webhook_event?(message)
+
     if message_type == 'contacts'
       create_contact_messages(message)
     else

--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -46,4 +46,12 @@ module Whatsapp::IncomingMessageServiceHelpers
   def unprocessable_message_type?(message_type)
     %w[reaction ephemeral unsupported].include?(message_type)
   end
+
+  def error_webhook_event?(message)
+    message.key?('errors')
+  end
+
+  def log_error(message)
+    Rails.logger.warn "Whatsapp Error: #{message['errors'][0]['title']} - contact: #{message['from']}"
+  end
 end

--- a/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_whatsapp_cloud_service_spec.rb
@@ -27,6 +27,35 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
       }.with_indifferent_access
     end
 
+    let(:error_params) do
+      {
+        phone_number: whatsapp_channel.phone_number,
+        object: 'whatsapp_business_account',
+        entry: [{
+          changes: [{
+            value: {
+              contacts: [{ profile: { name: 'Sojan Jose' }, wa_id: '2423423243' }],
+              messages: [{
+                from: '2423423243',
+                image: {
+                  id: 'b1c68f38-8734-4ad3-b4a1-ef0c10d683',
+                  mime_type: 'image/jpeg',
+                  sha256: '29ed500fa64eb55fc19dc4124acb300e5dcca0f822a301ae99944db',
+                  caption: 'Check out my product!'
+                },
+                errors: [{
+                  code: 400,
+                  details: 'Last error was: ServerThrottle. Http request error: HTTP response code said error. See logs for details',
+                  title: 'Media download failed: Not retrying as download is not retriable at this time'
+                }],
+                timestamp: '1664799904', type: 'image'
+              }]
+            }
+          }]
+        }]
+      }.with_indifferent_access
+    end
+
     context 'when valid attachment message params' do
       it 'creates appropriate conversations, message and contacts' do
         stub_request(:get, whatsapp_channel.media_url('b1c68f38-8734-4ad3-b4a1-ef0c10d683')).to_return(
@@ -64,6 +93,13 @@ describe Whatsapp::IncomingMessageWhatsappCloudService do
         expect(whatsapp_channel.inbox.messages.first.content).to eq('Check out my product!')
         expect(whatsapp_channel.inbox.messages.first.attachments.present?).to be false
         expect(whatsapp_channel.authorization_error_count).to eq(1)
+      end
+
+      it 'with attachment errors' do
+        described_class.new(inbox: whatsapp_channel.inbox, params: error_params).perform
+        expect(whatsapp_channel.inbox.conversations.count).not_to eq(0)
+        expect(Contact.all.first.name).to eq('Sojan Jose')
+        expect(whatsapp_channel.inbox.messages.count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
https://developers.facebook.com/docs/whatsapp/on-premises/webhooks/components

We are not going to handle the WhatsApp error component webhook event.

https://chatwoot-p3.sentry.io/issues/3957884597/?project=4504723538771968&query=is%3Aunresolved&referrer=issue-stream

Co-authored-by: Sojan Jose <sojan@pepalo.com>