### PR TITLE
chore: Revert gem update (#7792)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -598,7 +598,7 @@ GEM
       ffi (~> 1.0)
     redis (5.0.6)
       redis-client (>= 0.9.0)
-    redis-client (0.16.0)
+    redis-client (0.14.1)
       connection_pool
     redis-namespace (1.10.0)
       redis (>= 4)
@@ -713,7 +713,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.14.0)
-    sidekiq-cron (1.10.1)
+    sidekiq-cron (1.10.0)
       fugit (~> 1.8)
       globalid (>= 1.0.1)
       sidekiq (>= 6)


### PR DESCRIPTION
- updating redis client caused deployment issues in Heroku, hence reverting to prev version until its resolved